### PR TITLE
chore: add IServicioFirestore interface

### DIFF
--- a/Assets/Core/Application/UseCases/LoginUsuario.cs
+++ b/Assets/Core/Application/UseCases/LoginUsuario.cs
@@ -38,12 +38,12 @@ namespace PeriodicApp.Core.Application.UseCases
         {
             private ResultadoLogin(bool exito, string usuarioId, string mensajeError)
             {
-                Exito = exito;
+                EsExitoso = exito;
                 UsuarioId = usuarioId;
                 MensajeError = mensajeError;
             }
 
-            public bool Exito { get; }
+            public bool EsExitoso { get; }
 
             public string UsuarioId { get; }
 

--- a/Assets/Core/Domain/Interfaces/IServicioFirestore.cs
+++ b/Assets/Core/Domain/Interfaces/IServicioFirestore.cs
@@ -9,7 +9,7 @@ namespace PeriodicApp.Core.Domain.Interfaces
 
         Task GuardarDatosUsuario(string userId, Dictionary<string, object> data);
 
-        Task SubirJson(string userId, string misiones, string logros, string categorias);
+        Task SubirJson(string userId, string misiones, string categorias, string logros);
 
         Task ActualizarRango(string userId, int xpActual);
 

--- a/Assets/Infraestructure/Services/FirestoreService.cs
+++ b/Assets/Infraestructure/Services/FirestoreService.cs
@@ -2,137 +2,139 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Firebase.Firestore;
 using UnityEngine;
+using PeriodicApp.Core.Domain.Interfaces;
 
-public class FirestoreService :IServicioFirestore
+namespace PeriodicApp.Infrastructure.Services
 {
-    private readonly FirebaseFirestore firestore;
-
-    public FirestoreService(FirebaseFirestore firestore)
+    public sealed class FirestoreService : IServicioFirestore
     {
-        this.firestore = firestore;
-    }
+        private readonly FirebaseFirestore firestore;
 
-    public async Task<bool> NombreUsuarioDisponible(string nombre)
-    {
-        Query query = firestore.Collection("users").WhereEqualTo("DisplayName", nombre);
-        QuerySnapshot snapshot = await query.GetSnapshotAsync();
-
-        return snapshot.Count == 0;
-    }
-
-    public async Task GuardarDatosUsuario(string userId, Dictionary<string, object> data)
-    {
-        if (string.IsNullOrEmpty(userId))
+        public FirestoreService(FirebaseFirestore firestore)
         {
-            Debug.LogError("No se porporciono userId para GuardarDatosUsuario.");
+            this.firestore = firestore;
         }
 
-        DocumentReference docRef = firestore.Collection("users").Document(userId);
-        await docRef.SetAsync(data, SetOptions.MergeAll);
-        Debug.Log("Datos del usuario guardados correctamente");
-    }
-
-    public async Task SubirJson(string userId, string misionesJson, string categoriasJson, string logrosJson)
-    {
-        if (string.IsNullOrEmpty(userId))
+        public async Task<bool> NombreUsuarioDisponible(string nombre)
         {
-            Debug.LogError("UserId vacio al subir JSON");
+            Query query = firestore.Collection("users").WhereEqualTo("DisplayName", nombre);
+            QuerySnapshot snapshot = await query.GetSnapshotAsync();
+
+            return snapshot.Count == 0;
         }
 
-        List<Task> tareas = new List<Task>();
-
-        if(!string.IsNullOrEmpty(misionesJson) && misionesJson != "{}")
+        public async Task GuardarDatosUsuario(string userId, Dictionary<string, object> data)
         {
-            var data = new Dictionary<string, object>
+            if (string.IsNullOrEmpty(userId))
             {
-                { "misiones", misionesJson},
-                { "timestamp", FieldValue.ServerTimestamp}
-            };
+                Debug.LogError("No se porporciono userId para GuardarDatosUsuario.");
+            }
 
-            tareas.Add(firestore.Collection("users").Document(userId).Collection("datos").Document("misiones").SetAsync(data, SetOptions.MergeAll));
+            DocumentReference docRef = firestore.Collection("users").Document(userId);
+            await docRef.SetAsync(data, SetOptions.MergeAll);
+            Debug.Log("Datos del usuario guardados correctamente");
         }
 
-        if (!string.IsNullOrEmpty(logrosJson) && logrosJson != "{}")
+        public async Task SubirJson(string userId, string misionesJson, string categoriasJson, string logrosJson)
         {
-            var data = new Dictionary<string, object>
+            if (string.IsNullOrEmpty(userId))
             {
-                { "logros", logrosJson},
-                { "timestamp", FieldValue.ServerTimestamp}
-            };
+                Debug.LogError("UserId vacio al subir JSON");
+            }
 
-            tareas.Add(firestore.Collection("users").Document(userId).Collection("datos").Document("logros").SetAsync(data, SetOptions.MergeAll));
-        }
+            List<Task> tareas = new List<Task>();
 
-        if (!string.IsNullOrEmpty(categoriasJson) && categoriasJson != "{}")
-        {
-            var data = new Dictionary<string, object>
+            if (!string.IsNullOrEmpty(misionesJson) && misionesJson != "{}")
             {
-                {"categorias", categoriasJson },
-                {"timestamp", FieldValue.ServerTimestamp }
-            };
+                var data = new Dictionary<string, object>
+                {
+                    { "misiones", misionesJson},
+                    { "timestamp", FieldValue.ServerTimestamp}
+                };
 
-            tareas.Add(firestore.Collection("users").Document(userId).Collection("datos").Document("categorias").SetAsync(data, SetOptions.MergeAll));
-        }
+                tareas.Add(firestore.Collection("users").Document(userId).Collection("datos").Document("misiones").SetAsync(data, SetOptions.MergeAll));
+            }
 
-        if (tareas.Count > 0)
-        {
-            await Task.WhenAll(tareas);
-            Debug.Log("Misiones logros y categorias subidas correctamente");
-        }
-        else
-        {
-            Debug.LogWarning("No se encontraron datos validos para subir");
-        }
-    }
-
-    public async Task ActualizarRango(string userId, int xp)
-    {
-        if (string.IsNullOrEmpty(userId))
-        {
-            Debug.LogError("UserId vacio para actualizar rango. ");
-            return;
-        }
-
-        var docRef = firestore.Collection("users").Document(userId);
-        var snapshot = await docRef.GetSnapshotAsync();
-
-        if(snapshot.Exists && snapshot.ContainsField("Rango"))
-        {
-            string nuevoRango = CalcularRango(xp);
-            string rangoActual = snapshot.GetValue<string>("Rango");
-
-            if(nuevoRango != rangoActual)
+            if (!string.IsNullOrEmpty(logrosJson) && logrosJson != "{}")
             {
-                await docRef.UpdateAsync("Rango", nuevoRango);
-                Debug.Log("Rango actualizado a: {nuevoRango}");
+                var data = new Dictionary<string, object>
+                {
+                    { "logros", logrosJson},
+                    { "timestamp", FieldValue.ServerTimestamp}
+                };
+
+                tareas.Add(firestore.Collection("users").Document(userId).Collection("datos").Document("logros").SetAsync(data, SetOptions.MergeAll));
+            }
+
+            if (!string.IsNullOrEmpty(categoriasJson) && categoriasJson != "{}")
+            {
+                var data = new Dictionary<string, object>
+                {
+                    {"categorias", categoriasJson },
+                    {"timestamp", FieldValue.ServerTimestamp }
+                };
+
+                tareas.Add(firestore.Collection("users").Document(userId).Collection("datos").Document("categorias").SetAsync(data, SetOptions.MergeAll));
+            }
+
+            if (tareas.Count > 0)
+            {
+                await Task.WhenAll(tareas);
+                Debug.Log("Misiones logros y categorias subidas correctamente");
+            }
+            else
+            {
+                Debug.LogWarning("No se encontraron datos validos para subir");
             }
         }
+
+        public async Task ActualizarRango(string userId, int xp)
+        {
+            if (string.IsNullOrEmpty(userId))
+            {
+                Debug.LogError("UserId vacio para actualizar rango. ");
+                return;
+            }
+
+            var docRef = firestore.Collection("users").Document(userId);
+            var snapshot = await docRef.GetSnapshotAsync();
+
+            if (snapshot.Exists && snapshot.ContainsField("Rango"))
+            {
+                string nuevoRango = CalcularRango(xp);
+                string rangoActual = snapshot.GetValue<string>("Rango");
+
+                if (nuevoRango != rangoActual)
+                {
+                    await docRef.UpdateAsync("Rango", nuevoRango);
+                    Debug.Log($"Rango actualizado a: {nuevoRango}");
+                }
+            }
+        }
+
+        private string CalcularRango(int xp)
+        {
+            if (xp >= 25000) return "Amo del caos qumico";
+            if (xp >= 9000) return "Visionario Cuntico";
+            if (xp >= 3000) return "Arquitecto molecular";
+            return "Novato de laboratorio";
+        }
+
+        public async Task<Dictionary<string, object>> ObtenerUsuarioAsync(string userId)
+        {
+            DocumentSnapshot snapshot = await FirebaseFirestore.DefaultInstance.Collection("users").Document(userId).GetSnapshotAsync();
+
+            if (snapshot.Exists)
+                return snapshot.ToDictionary();
+
+            return new Dictionary<string, object>();
+        }
+
+        public async Task GuardarEstadoEncuestaConocimientoAsync(string userId, bool estado)
+        {
+            var firestore = FirebaseFirestore.DefaultInstance;
+            var userRef = firestore.Collection("users").Document(userId);
+            await userRef.UpdateAsync("EstadoEncuestaConocimiento", estado);
+        }
     }
-
-    private string CalcularRango(int xp)
-    {
-        if (xp >= 25000) return "Amo del caos químico";
-        if (xp >= 9000) return "Visionario Cuántico";
-        if (xp >= 3000) return "Arquitecto molecular";
-        return "Novato de laboratorio";
-    }
-
-    public async Task<Dictionary<string, object>> ObtenerUsuarioAsync(string userId)
-    {
-        DocumentSnapshot snapshot = await FirebaseFirestore.DefaultInstance.Collection("users").Document(userId).GetSnapshotAsync();
-
-        if (snapshot.Exists)
-            return snapshot.ToDictionary();
-
-        return new Dictionary<string, object>();
-    }
-
-    public async Task GuardarEstadoEncuestaConocimientoAsync(string userId, bool estado)
-    {
-        var firestore = FirebaseFirestore.DefaultInstance;
-        var userRef = firestore.Collection("users").Document(userId);
-        await userRef.UpdateAsync("EstadoEncuestaConocimiento", estado);
-    }
-
-
 }


### PR DESCRIPTION
## Summary
- add the IServicioFirestore abstraction with the signatures required by FirestoreService
- register FirestoreService inside the infrastructure namespace and implement the interface contract
- rename the ResultadoLogin success flag to avoid duplicating the Exito identifier

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d5b9797dac832cab7304e88f92e27e